### PR TITLE
feat: enable HA mopidy extension

### DIFF
--- a/config.json
+++ b/config.json
@@ -227,8 +227,10 @@
     {
       "name": "announcer",
       "Name": "Announcer",
+      "home_assistant": {
+        "use_mopidy": false
+      },
       "mopidy": {
-        "http_port": "6680",
         "mpd_port": "6600",
         "mpd_only": true
       },

--- a/config.json
+++ b/config.json
@@ -12,6 +12,9 @@
   "chromecast": {
     "device": "default:CARD=ICUSBAUDIO7D"
   },
+  "home_assistant": {
+    "use_mopidy": false
+  },
   "mopidy": {
     "host": "media",
     "path": "/var/lib/mopidy/bin/mopidy"

--- a/templates/home-assistant.yaml.template
+++ b/templates/home-assistant.yaml.template
@@ -1,11 +1,19 @@
 {{#zone}}
 media_player:
-  - platform: mpd
-    {{! use slugified name if available}}
-    name: {{#name_}}{{name_}}{{/name_}}{{^name_}}{{name}}{{/name_}}_mpd
     {{! use localhost for dev}}
-    host: {{#dev}}localhost{{/dev}}{{^dev}}{{mopidy.host}}{{/dev}}
+  - host: {{#dev}}localhost{{/dev}}{{^dev}}{{mopidy.host}}{{/dev}}
+    {{! use mopidy custom extension if enabled}}
+    {{#home_assistant.use_mopidy}}
+    {{! use slugified name if available}}
+    name: {{#name_}}{{name_}}{{/name_}}{{^name_}}{{name}}{{/name_}}_mopidy
+    port: {{mopidy.http_port}}
+    platform: mopidy
+    {{/home_assistant.use_mopidy}}
+    {{^home_assistant.use_mopidy}}
+    name: {{#name_}}{{name_}}{{/name_}}{{^name_}}{{name}}{{/name_}}_mpd
     port: {{mopidy.mpd_port}}
+    platform: mpd
+    {{/home_assistant.use_mopidy}}
 {{#kodi}}
 
   - platform: kodi
@@ -17,7 +25,12 @@ media_player:
   - platform: group
     name: {{#name_}}{{name_}}{{/name_}}{{^name_}}{{name}}{{/name_}}_multizone_audio
     entities:
+      {{#home_assistant.use_mopidy}}
+      - media_player.{{#name_}}{{name_}}{{/name_}}{{^name_}}{{name}}{{/name_}}_mopidy
+      {{/home_assistant.use_mopidy}}
+      {{^home_assistant.use_mopidy}}
       - media_player.{{#name_}}{{name_}}{{/name_}}{{^name_}}{{name}}{{/name_}}_mpd
+      {{/home_assistant.use_mopidy}}
       {{#kodi}}
       - media_player.{{#name_}}{{name_}}{{/name_}}{{^name_}}{{name}}{{/name_}}_kodi
       {{/kodi}}


### PR DESCRIPTION
Use @bushvin's custom mopidy integration for HomeAssistant from https://github.com/bushvin/hass-integrations instead of the core mpd integration