### PR TITLE
fix #44: name audio devices

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -186,6 +186,9 @@ $(output_dir)/iris.%.conf: $(CONFIG) templates/iris.template $(RENDER)
 $(output_dir)/home-assistant.%.yaml: $(CONFIG) templates/home-assistant.yaml.template
 	$(RENDER) -z $* -d $< templates/home-assistant.yaml.template > $@
 
+$(output_dir)/70-multizone-audio.%.rules: $(CONFIG) templates/70-multizone-audio.rules.template $(RENDER)
+	$(RENDER) -z $* -d $< templates/70-multizone-audio.rules.template > $@
+
 
 snapserver: $(output_dir)/snapserver.conf
 	systemctl $(SYSTEMCTL_USER) restart snapserver

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ A **config generator** for a multizone audio system based on snapcast, Mopidy an
 - [ ] no snapcast controls visible to end-users(!)
 - [x] eliminate unnecessary software volume controls
 - [x] replaygain support
+- [x] supports multiple audio outputs per player
 
 # Architecture
 

--- a/example.config.json
+++ b/example.config.json
@@ -99,6 +99,35 @@
       },
       "streams": ["spotify", "airplay", "iris"],
       "other_streams": ["Google Chromecast"]
+    },
+    {
+      "name": "room-with-static-soundcard-name",
+      "name_": "room_with_static_soundcard_name",
+      "Name": "Room with Static Soundcard Name",
+      "airplay": {
+        "port": "5112"
+      },
+      "mopidy": {
+        "http_port": "6692",
+        "mpd_port": "6612"
+      },
+      "snapcast": {
+        "latency": 0,
+        "opts": "-s MyCard --mixer=hardware",
+        "volume": 65
+      },
+      "spotify": {
+        "api_port": "24812",
+        "crossfade_ms": "0",
+        "zeroconf": "39812"
+      },
+      "udev": {
+        "soundcard": {
+            "name": "MyCard",
+            "path": "/devices/platform/soc/3f980000.usb/usb1/1-1/1-1.2/1-1.2:1.0/sound"
+        }
+      },
+      "streams": ["spotify", "airplay", "iris"]
     }
   ],
   "announcers": [

--- a/templates/70-multizone-audio.rules.template
+++ b/templates/70-multizone-audio.rules.template
@@ -1,0 +1,4 @@
+# multizone-audio: give soundcards deterministic names
+{{#zone.udev.soundcard}}
+ACTION=="add", SUBSYSTEM=="sound", DEVPATH=="{{path}}/card?", ATTR{id}="{{name}}"
+{{/zone.udev.soundcard}}


### PR DESCRIPTION
To Do:

- [ ] figure out a way to install them only when needed

Or:

- [ ] install for all zones to provide a predictable name for multizone sound cards

Some services may already be configured to use sound cards by their old name. Common enough (given dmix)?